### PR TITLE
fix: corregido error en dias_entre 

### DIFF
--- a/arrendatools/plantillas/filters/fechas.py
+++ b/arrendatools/plantillas/filters/fechas.py
@@ -86,7 +86,8 @@ def trimestre(fecha, delta=0):
 def dias_entre(fecha_inicio, fecha_fin):
     """
     Calcula los dias transcurridos entre 2 fechas.
-    El cálculo sólo cuenta días enteros, esto significa que si se quiere contar el día final entero hay que sumar 1 día.
+    Sólo cuenta días enteros, esto significa que si se quiere contar el día final hay que sumar 1 día a la fecha final.
+    Si las fechas contienen la hora (con zona horaria) se elimina y se tiene en cuenta únicamente la fecha.
     Por ejemplo:
         fecha_incio: 2023-12-01
         fecha_fin: 2023-12-31.
@@ -100,6 +101,8 @@ def dias_entre(fecha_inicio, fecha_fin):
     Returns:
         int: Número de días enteros que han transcurrido entre las 2 fechas.
     """
-    fecha_inicio_obj = datetime.fromisoformat(fecha_inicio)
-    fecha_fin_obj = datetime.fromisoformat(fecha_fin)
+    fecha_inicio_obj = datetime.fromisoformat(fecha_inicio).astimezone(tz=None).date()
+    print(fecha_inicio_obj)
+    fecha_fin_obj = datetime.fromisoformat(fecha_fin).astimezone(tz=None).date()
+    print(fecha_fin_obj)
     return (fecha_fin_obj - fecha_inicio_obj).days

--- a/test/test_fechas.py
+++ b/test/test_fechas.py
@@ -32,6 +32,8 @@ class TestFunciones(unittest.TestCase):
         self.assertEqual(dias_entre('2023-01-01', '2024-01-01'), 365)
         self.assertEqual(dias_entre('2023-06-01', '2024-01-01'), 214)
         self.assertEqual(dias_entre('2024-01-01', '2025-01-01'), 366)
+        self.assertEqual(dias_entre('2022-06-01T22:00:00.000Z', '2022-12-31T23:00:00.000Z'), 213)
+        self.assertEqual(dias_entre('2022-06-01T22:00:00.000Z', '2023-01-01'), 213)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
si metias una fecha con hora y otra sin, fallaba la ejecucion

en el caso que exista la hora, se elimina de la fecha y se convierte solo a fecha